### PR TITLE
Unique UUID

### DIFF
--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -3,3 +3,4 @@
 /target
 /Cargo.lock
 cfg.toml
+*.txt

--- a/firmware/common/lib/get-uuid/Cargo.toml
+++ b/firmware/common/lib/get-uuid/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "get-uuid"
 version = "0.1.0"
-authors = [
-    "Anatol Ulrich <anatol.ulrich@ferrous-systems.com>",
-    "Sergio Gasquez <sergio.gasquez@gmail.com>",
-]
+authors = ["Michael Morgan <morgan.mike55@gmail.com>"]
 edition = "2021"
 
 [dependencies]
 anyhow = "=1.0.95"
+esp-idf-sys = "0.36.1"
+heapless = "0.7"
 
 [build-dependencies]
 anyhow = "=1.0.95"
-uuid   = { version = "=1.9.1", features = ["v4"] }
+uuid = { version = "=1.9.1", features = ["v4"] }

--- a/firmware/common/lib/get-uuid/src/lib.rs
+++ b/firmware/common/lib/get-uuid/src/lib.rs
@@ -1,5 +1,36 @@
-include!(concat!(env!("CARGO_MANIFEST_DIR"), "/_uuid.rs"));
+use core::fmt::Write;
+use esp_idf_sys::esp_efuse_mac_get_default;
+use heapless::String;
 
-pub const fn uuid() -> &'static str {
-    UUID
+pub fn uuid() -> String<16> {
+    // Step 1: make a 6-byte buffer
+    let mut mac_bytes: [u8; 6] = [0; 6];
+
+    // Step 2: call the C function to fill it
+    // SAFETY: must be called after ESP system is up
+    let err = unsafe { esp_efuse_mac_get_default(mac_bytes.as_mut_ptr()) };
+    if err != esp_idf_sys::ESP_OK {
+        // Handling error by returning zeros
+        let mut s = String::new();
+        write!(s, "000000000000").unwrap();
+        return s;
+    }
+
+    // Step 3: pack those bytes into a u64
+    // bitwise operators to pack 6 separate bytes into one 48-bit int stored in a 64-bit int
+    let mac_raw: u64 = (mac_bytes[0] as u64) << 40
+        | (mac_bytes[1] as u64) << 32
+        | (mac_bytes[2] as u64) << 24
+        | (mac_bytes[3] as u64) << 16
+        | (mac_bytes[4] as u64) << 8
+        | (mac_bytes[5] as u64);
+
+    // Step 4: split high/low for formatting
+    let hi = (mac_raw >> 32) as u16;
+    let lo = mac_raw as u32;
+
+    let mut s = String::<16>::new();
+    // this gives you a 12-hex-digit uppercase string, e.g. "A1B2C3D4E5F6"
+    write!(s, "{:04X}{:08X}", hi, lo).unwrap();
+    s
 }

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -18,7 +18,7 @@ use log::info;
 use std::{thread::sleep, time::Duration};
 use wifi::wifi;
 
-const UUID: &str = get_uuid::uuid();
+//const UUID: &str = get_uuid::uuid();
 
 #[toml_cfg::toml_config]
 pub struct Config {
@@ -59,8 +59,10 @@ fn main() -> Result<()> {
     )?;
     info!("Successfully connected to Wi-Fi");
 
+    let uuid = get_uuid::uuid();
+
     info!("Our UUID is:");
-    info!("{}", UUID);
+    info!("{}", uuid);
 
     // Set up I2C communication for the sensor
     let sda = peripherals.pins.gpio21;
@@ -106,7 +108,7 @@ fn main() -> Result<()> {
 
         // Publish temperature data via MQTT
         client.enqueue(
-            &mqtt_messages::temperature_data_topic(UUID),
+            &mqtt_messages::temperature_data_topic(&uuid),
             QoS::AtLeastOnce,
             false,
             temp_str.as_bytes(),

--- a/firmware/src/main.rs
+++ b/firmware/src/main.rs
@@ -18,8 +18,6 @@ use log::info;
 use std::{thread::sleep, time::Duration};
 use wifi::wifi;
 
-//const UUID: &str = get_uuid::uuid();
-
 #[toml_cfg::toml_config]
 pub struct Config {
     #[default("localhost")]


### PR DESCRIPTION
- Changed get-uuid to obtain the unique MAC address from the chips non-volatile eFuse storage 
- Chips now have unique ID's to target